### PR TITLE
Assign string values to Relation enum cases

### DIFF
--- a/src/Enum/Relation.php
+++ b/src/Enum/Relation.php
@@ -7,16 +7,17 @@ namespace ByJG\AnyDataset\Core\Enum;
  *
  * Use this in AddRelation method.
  */
-enum Relation
+enum Relation: string
 {
-    case EQUAL;
-    case LESS_THAN;
-    case GREATER_THAN;
-    case LESS_OR_EQUAL_THAN;
-    case GREATER_OR_EQUAL_THAN;
-    case NOT_EQUAL;
-    case STARTS_WITH;
-    case CONTAINS;
-    case IN;
-    case NOT_IN;
+    case EQUAL = '=';
+    case LESS_THAN = '<';
+    case GREATER_THAN = '>';
+    case LESS_OR_EQUAL_THAN = '<=';
+    case GREATER_OR_EQUAL_THAN = '>=';
+    case NOT_EQUAL = '<>';
+    case STARTS_WITH = 'STARTS WITH';
+    case CONTAINS = 'CONTAINS';
+    case IN = 'IN';
+    case NOT_IN = 'NOT IN';
+
 }


### PR DESCRIPTION
```
- Assigned string representations to all `Relation` enum cases to improve serializability and maintain clarity in code representations.
```

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Assign specific string values to each case of the `Relation` enum.

### Why are these changes being made?

These changes provide explicit string representations for each relation type to improve readability and usage consistency when `Relation` values are used in string context, such as SQL queries or logging, ensuring clear and direct mapping between enum cases and their expected values.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->